### PR TITLE
fix: remove deprecated ephemeral resources from list

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,21 @@ jobs:
           terraform init
 
           echo "Generating ephemeral resources from providers..."
-          terraform providers schema -json | jq '{"ephemeral": [.provider_schemas | to_entries[] | .value.ephemeral_resource_schemas? | select(.) | keys[] ]}' > ../../data/ephemeral/gen_schema_ephemerals.json
+          terraform providers schema -json | jq '
+          {
+            "ephemeral": [
+              .provider_schemas | 
+              to_entries[] as $provider |
+              $provider.value.ephemeral_resource_schemas? |
+              select(.) |
+              to_entries[] |
+              select(
+                (.value.block.deprecated? != true) and
+                ((.value.block.description? // "" | test("deprecated|obsolete|removed"; "i")) | not)
+              ) |
+              .key
+            ]
+          }' > ../../data/ephemeral/gen_schema_ephemerals.json
           
           # Generate list for write-only resources.
           echo "Generating write-only resources from providers..."


### PR DESCRIPTION
# Description

Updated the ephemeral resource identification to remove any resources marked as deprecated. 

Resolves #18 


### Filters only the deprecated resources
```
terraform providers schema -json | jq '
# Check all ephemeral resources for deprecation indicators
.provider_schemas | 
to_entries[] as $provider |
$provider.value.ephemeral_resource_schemas? |
select(.) |
to_entries[] |
{
  provider: $provider.key,
  resource: .key,
  deprecated: .value.block.deprecated?,
  deprecation_message: .value.block.deprecation_message?,
  description: .value.block.description?
} |
select(.deprecated == true or (.description // "" | test("deprecated|obsolete|removed"; "i")))
'
```

### Output of the above script

```
{
  "provider": "registry.terraform.io/hashicorp/tfe",
  "resource": "tfe_agent_token",
  "deprecated": true,
  "deprecation_message": null,
  "description": "This ephemeral resource can be used to retrieve an agent token without saving its value in state."
}
{
  "provider": "registry.terraform.io/hashicorp/tfe",
  "resource": "tfe_audit_trail_token",
  "deprecated": true,
  "deprecation_message": null,
  "description": "This ephemeral resource can be used to retrieve an audit trail token without saving its value in state. Using this ephemeral resource will generate a new token each time it is used, invalidating any existing audit trail token."
}
{
  "provider": "registry.terraform.io/hashicorp/tfe",
  "resource": "tfe_organization_token",
  "deprecated": true,
  "deprecation_message": null,
  "description": "This ephemeral resource can be used to retrieve an organization token without saving its value in state. Using this ephemeral resource will generate a new token each time it is used, invalidating any existing organization token."
}

```

### Result from the updated script snippet

```
"ephemeral": [
    "aws_cognito_identity_openid_token_for_developer_identity",
    "aws_eks_cluster_auth",
    "aws_kms_secrets",
    "aws_lambda_invocation",
    "aws_secretsmanager_random_password",
    "aws_secretsmanager_secret_version",
    "aws_ssm_parameter",
    "azurerm_key_vault_certificate",
    "azurerm_key_vault_secret",
    "google_service_account_access_token",
    "google_service_account_id_token",
    "google_service_account_jwt",
    "google_service_account_key",
    "kubernetes_certificate_signing_request_v1",
    "kubernetes_token_request_v1",
    "random_password",
    "tfe_outputs",
    "tfe_team_token",
    "tls_private_key",
    "vault_database_secret",
    "vault_kv_secret_v2"
  ]

```
